### PR TITLE
22313 fix estimator tests

### DIFF
--- a/non_deterministic.py
+++ b/non_deterministic.py
@@ -1,0 +1,36 @@
+import numpy as np
+from sklearn.utils.estimator_checks import parametrize_with_checks
+from sklearn.base import BaseEstimator, ClassifierMixin, check_X_y
+from sklearn.utils.validation import check_array, check_is_fitted, check_random_state
+
+
+class TemplateEstimator(BaseEstimator, ClassifierMixin):
+    def __init__(self, threshold=0.5, random_state=None):
+        self.threshold = threshold
+        self.random_state = random_state
+
+    def fit(self, X, y):
+        self.random_state_ = check_random_state(self.random_state)
+        X, y = check_X_y(X, y)
+        self.classes_ = np.unique(y)
+        self.fitted_ = True
+        return self
+
+    def predict(self, X):
+        check_is_fitted(self)
+        X = check_array(X)
+
+        y_hat = self.random_state_.choice(self.classes_, size=X.shape[0])
+        return y_hat
+
+    def _more_tags(self):
+        return {
+            "non_deterministic": True,
+            "no_validation": True,
+            "poor_score": True,
+        }
+
+
+@parametrize_with_checks([TemplateEstimator()])
+def test_sklearn_compatible_estimator(estimator, check):
+    check(estimator)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -317,8 +317,9 @@ def _yield_all_checks(estimator):
         for check in _yield_outliers_checks(estimator):
             yield check
     yield check_parameters_default_constructible
-    yield check_methods_sample_order_invariance
-    yield check_methods_subset_invariance
+    if not tags["non_deterministic"]:
+        yield check_methods_sample_order_invariance
+        yield check_methods_subset_invariance
     yield check_fit2d_1sample
     yield check_fit2d_1feature
     yield check_get_params_invariance

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -317,9 +317,8 @@ def _yield_all_checks(estimator):
         for check in _yield_outliers_checks(estimator):
             yield check
     yield check_parameters_default_constructible
-    if not tags["non_deterministic"]:
-        yield check_methods_sample_order_invariance
-        yield check_methods_subset_invariance
+    yield check_methods_sample_order_invariance
+    yield check_methods_subset_invariance
     yield check_fit2d_1sample
     yield check_fit2d_1feature
     yield check_get_params_invariance
@@ -1281,6 +1280,9 @@ def _apply_on_subsets(func, X):
 
 @ignore_warnings(category=FutureWarning)
 def check_methods_subset_invariance(name, estimator_orig):
+    if _safe_tags(estimator_orig, key="non_deterministic"):
+        msg = name + " is non deterministic"
+        raise SkipTest(msg)
     # check that method gives invariant results if applied
     # on mini batches or the whole set
     rnd = np.random.RandomState(0)
@@ -1319,6 +1321,9 @@ def check_methods_subset_invariance(name, estimator_orig):
 
 @ignore_warnings(category=FutureWarning)
 def check_methods_sample_order_invariance(name, estimator_orig):
+    if _safe_tags(estimator_orig, key="non_deterministic"):
+        msg = name + " is non deterministic"
+        raise SkipTest(msg)
     # check that method gives invariant results if applied
     # on a subset with different sample order
     rnd = np.random.RandomState(0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #22313

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

When the non_deterministic tag is present in an estimator under test, two tests `check_methods_subset_invariance` and `check_methods_sample_order_invariance` are skipped with a user friendly message displayed showing why the test was skipped.

#### Any other comments?

N/A.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
