### PR TITLE
implemented 22055 feature with comprehensive tests

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -319,13 +319,22 @@ class BaseEstimator:
             state = self.__dict__.copy()
 
         if type(self).__module__.startswith("sklearn."):
-            return dict(state.items(), _sklearn_version=__version__)
+            return dict(state.items(), _sklearn_pickle_version=__version__)
         else:
             return state
 
     def __setstate__(self, state):
         if type(self).__module__.startswith("sklearn."):
+            # If scikit learn has been upgraded and 
+            # the pickle file contains the old _sklearn_version attribute
+            # the following code checks for that case
             pickle_version = state.pop("_sklearn_version", "pre-0.18")
+            
+            if not "_sklearn_pickle_version" in state:
+                state["_sklearn_pickle_version"] = pickle_version
+
+            pickle_version = state["_sklearn_pickle_version"]
+
             if pickle_version != __version__:
                 warnings.warn(
                     "Trying to unpickle estimator {0} from version {1} when "


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Implements the feature requested at scikit-learn#22055.

#### What does this implement/fix? Explain your changes.

Implements the feature requested to store the original version from which an estimator was pickled.  Stores this information in `_sklearn_pickle_version` of the state of `BaseEstimator`. This will not exist if an estimator has not been pickled before. Also include some backwards compatibility to ensure that older versions store this `_sklearn_pickle_version`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
